### PR TITLE
Resolve properties such as ${reference|} to an empty string

### DIFF
--- a/src/main/java/org/nnsoft/guice/rocoto/configuration/resolver/PropertiesResolverProvider.java
+++ b/src/main/java/org/nnsoft/guice/rocoto/configuration/resolver/PropertiesResolverProvider.java
@@ -19,7 +19,6 @@ import static com.google.inject.util.Providers.of;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.StringTokenizer;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -96,13 +95,13 @@ public final class PropertiesResolverProvider
                 {
                     throw new ProvisionException( "Syntax error in property: " + pattern );
                 }
-                StringTokenizer keyTokenizer =
-                    new StringTokenizer( pattern.substring( pos + 2, endName ), PIPE_SEPARATOR );
-                String key = keyTokenizer.nextToken().trim();
+                String key = pattern.substring( pos + 2, endName ).trim();
                 String defaultValue = null;
-                if ( keyTokenizer.hasMoreTokens() )
+                int pipeAt = key.indexOf( PIPE_SEPARATOR );
+                if (pipeAt >= 0)
                 {
-                    defaultValue = keyTokenizer.nextToken().trim();
+                    key = key.substring( 0, pipeAt ).trim();
+                    defaultValue = key.substring( pipeAt, key.length() ).trim();
                 }
                 VariableResolverProvider variableResolver = new VariableResolverProvider( key, defaultValue );
                 fragments.add( variableResolver );

--- a/src/test/java/org/nnsoft/guice/rocoto/configuration/ConfigurationModuleTestCase.java
+++ b/src/test/java/org/nnsoft/guice/rocoto/configuration/ConfigurationModuleTestCase.java
@@ -117,6 +117,7 @@ public final class ConfigurationModuleTestCase
         assert "ldap.${not.found}".equals( this.ldapConfiguration.getHost() );
         assert 389 == this.ldapConfiguration.getPort();
         assert this.ldapConfiguration.getBaseDN().indexOf( '$' ) < 0;
+        assert "".equals( this.ldapConfiguration.getUser() );
     }
 
     @Test( dependsOnMethods = "doInject" )

--- a/src/test/java/org/nnsoft/guice/rocoto/configuration/LdapConfiguration.java
+++ b/src/test/java/org/nnsoft/guice/rocoto/configuration/LdapConfiguration.java
@@ -36,6 +36,10 @@ public final class LdapConfiguration
     @Named( "ldap.baseDN" )
     private String baseDN;
 
+    @Inject
+    @Named( "ldap.user" )
+    private String user;
+
     public String getHost()
     {
         return host;
@@ -64,6 +68,16 @@ public final class LdapConfiguration
     public void setBaseDN( String baseDN )
     {
         this.baseDN = baseDN;
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    public void setUser( String user )
+    {
+        this.user = user;
     }
 
 }

--- a/src/test/resources/org/nnsoft/guice/rocoto/configuration/ldap.properties
+++ b/src/test/resources/org/nnsoft/guice/rocoto/configuration/ldap.properties
@@ -16,3 +16,4 @@
 ldap.host=ldap.${not.found}
 ldap.port=389
 ldap.baseDN=ou=${user.name}, dc=${env.HOME}, dc=edu
+ldap.user=${ldap.user|}


### PR DESCRIPTION
Currently, when you have a property that references another undefined property, such as ${reference|}, it will resolve to the string literal ${reference}. However, the expected behavior is for it to resolve to an empty string. This pull request addresses this issue.
