### PR TITLE
Fix Guice > 4.1 error with Rocoto module implementation

### DIFF
--- a/src/main/java/org/nnsoft/guice/rocoto/Rocoto.java
+++ b/src/main/java/org/nnsoft/guice/rocoto/Rocoto.java
@@ -32,8 +32,10 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
+import com.google.inject.spi.DefaultBindingTargetVisitor;
 import com.google.inject.spi.DefaultElementVisitor;
 import com.google.inject.spi.Element;
+import com.google.inject.spi.InstanceBinding;
 
 /**
  * @since 6.0
@@ -95,7 +97,7 @@ public final class Rocoto
                             propertyKey = ( (javax.inject.Named) bindingKey.getAnnotation() ).value();
                         }
 
-                        String propertyValue = (String) binding.getProvider().get();
+                        String propertyValue = getPropertyValue((Binding<String>) binding);
 
                         variablesMap.put( propertyKey, propertyValue );
                     }
@@ -112,4 +114,13 @@ public final class Rocoto
         }
     }
 
+    static String getPropertyValue(Binding<String> binding) {
+      return binding.acceptTargetVisitor(new DefaultBindingTargetVisitor<String, String>() {
+
+        @Override
+        public String visit(InstanceBinding<? extends String> instanceBinding) {
+          return instanceBinding.getInstance();
+        }});
+    }
+    
 }


### PR DESCRIPTION
Invoking the getProvider() method on an InstanceBinding in Guice versions 4.2 or later result in a runtime exception as documented in this issue: 99soft/rocoto#12

This pull request addresses the issue by using a BindingTargetVisitor to interrogate the InstanceBinding and retrieve the bound String value.  I'm not sure this is the best way to correct the problem, but the existing unit tests pass when linked against Guice 4.2.3 and Guava 30.1-jre, as well Guice 4.0 and Guava 18.0 as defined in the current pom.xml.

